### PR TITLE
bugfix: people strict mode was broken

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -96,6 +96,7 @@ class Immich:
         search_params = {
             "isVisible": True,
             "withExif": True,
+            "withPeople": True,
         }
 
         if country:


### PR DESCRIPTION
In one of the recent immich version (post v2.5), the API was changed, so that people information was only returned when the 'withPeople' parameter was given. This resulted in the people strict mode being broken, as it relied on the people information available in the response payload.