### PR TITLE
feat: configurable optional start delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ services:
             IMMICH_API_KEY: API_KEY
             CONFIG_FILE: /config/dynamic-albums.json
             SCHEDULE_INTERVAL: 1440 # 1440 minutes, meaning once per day
+            START_DELAY: 120 # 2 minutes which gives the immich instance some time to startup
             PYTHONUNBUFFERED: True # ensure stdout is flushed on every print
         env_file:
             - .env

--- a/sync.py
+++ b/sync.py
@@ -398,6 +398,12 @@ def parse_args():
         default=os.environ.get("SCHEDULE_INTERVAL", 0),
         help="Schedule interval in minutes",
     )
+    parser.add_argument(
+        "--start-delay",
+        type=int,
+        default=os.environ.get("START_DELAY", 0),
+        help="Delay the initial albums update (in seconds)",
+    )
 
     return parser.parse_args()
 
@@ -408,7 +414,10 @@ def main():
     assert args.immich_api_key, "immich-api-key is required"
     assert args.config_file, "config-file is required"
 
-    # run immediately ...
+    # delay the initial start (e.g. to give time for the immich container to start) ...
+    time.sleep(int(args.start_delay))
+
+    # ... then run the sync process ...
     sync_albums(args)
 
     # ... and then schedule a job to continuously run (optionally)


### PR DESCRIPTION
As the depends_on docker compose option is not working very reliable, sometimes it makes sense to delay the start of the dynamic albums container a bit to ensure the immich instance is fully started. This can now be done with the new optional start delay parameter.